### PR TITLE
feat: add very basic syntax highlighting

### DIFF
--- a/src/jvmMain/kotlin/ui/codeview/InstructionViewer.kt
+++ b/src/jvmMain/kotlin/ui/codeview/InstructionViewer.kt
@@ -1,11 +1,7 @@
 package ui.codeview
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -13,7 +9,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import data.InstructionRecord
@@ -47,10 +46,15 @@ fun InstructionViewer(instruction: InstructionRecord, maxOffsetLength: Int, colo
         )
 
         Text(
-            instruction.instruction,
             style = MaterialTheme.typography.bodySmall,
             fontFamily = FontFamily.Monospace,
             modifier = Modifier.padding(start = 16.dp),
+            text = buildAnnotatedString {
+                append(instruction.instruction)
+                if (instruction.instruction.contains(' ')) {
+                    addStyle(style = SpanStyle(color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.SemiBold), instruction.instruction.indexOf(' '), instruction.instruction.length)
+                }
+            }
         )
     }
 }


### PR DESCRIPTION
Currently just splits the string in 2 so the arguments have a different colour than the opcode but this does mean that things like commas are also highlighted.

Result:
![image](https://github.com/Mouwrice/proguard-core-visualizer/assets/15368970/bc9a75eb-4fcc-4dea-b2c2-d815b89e9dc9)
<details> 
<summary>Or in light mode(carefully placed in a spoiler): </summary>
<img src=https://github.com/Mouwrice/proguard-core-visualizer/assets/15368970/804960d8-4552-4386-9415-333fb693716e></img>
</details>
