### PR TITLE
fix: read dex files instead of just converting

### DIFF
--- a/src/jvmMain/kotlin/data/LoadUtil.kt
+++ b/src/jvmMain/kotlin/data/LoadUtil.kt
@@ -74,7 +74,7 @@ class LoadUtil {
             // Convert dex files to a JAR first.
             classReader = NameFilteredDataEntryReader(
                 "classes*.dex",
-                DexClassReader(false, classPoolFiller),
+                DexClassReader(true, classPoolFiller),
                 classReader,
             )
 


### PR DESCRIPTION
Closes:#96 
The dex code was not read and hence we could not display the content of apk files.

Before:
![image](https://github.com/Mouwrice/proguard-core-visualizer/assets/56763273/a79bc4bc-798a-4622-b8d5-1284e1fd12db)


After:
![image](https://github.com/Mouwrice/proguard-core-visualizer/assets/56763273/f71097e2-e09f-41aa-96da-908b3f872be8)
